### PR TITLE
Add snapshot and mfssubfolder support; fix /proc/mounts regex

### DIFF
--- a/MooseFSPlugin.pm
+++ b/MooseFSPlugin.pm
@@ -13,10 +13,8 @@ use PVE::ProcFSTools;
 use base qw(PVE::Storage::Plugin);
 
 # MooseFS helper functions
-
 sub moosefs_is_mounted {
     my ($mfsmaster, $mfsport, $mountpoint, $mountdata) = @_;
-
     $mountdata = PVE::ProcFSTools::parse_proc_mounts() if !$mountdata;
 
     # Check that we return something like mfs#10.1.1.201:9421
@@ -30,19 +28,55 @@ sub moosefs_is_mounted {
 }
 
 sub moosefs_mount {
-    my ($mfsmaster, $mountpoint, $mfspassword) = @_;
+    my ($scfg) = @_;
 
-    my $cmd;
-    if (defined $mfspassword) {
-        $cmd = ['/usr/bin/mfsmount', '-o', 'mfspassword='.$mfspassword, '-H', $mfsmaster, $mountpoint];
-    } else {
-        $cmd = ['/usr/bin/mfsmount', '-H', $mfsmaster, $mountpoint];
+    my $mfsmaster = $scfg->{mfsmaster};
+
+    my $mfspassword = $scfg->{mfspassword};
+
+    my $mfsport = $scfg->{mfsport};
+
+    my $mfssubfolder = $scfg->{mfssubfolder};
+
+    my $cmd = ['/usr/bin/mfsmount'];
+
+    if (defined $mfsmaster) {
+        push @$cmd, '-o', "mfsmaster=$mfsmaster";
     }
+
+    if (defined $mfsport) {
+        push @$cmd, '-o', "mfsport=$mfsport";
+    }
+
+    if (defined $mfspassword) {
+        push @$cmd, '-o', "mfspassword=$mfspassword";
+    }
+
+    if (defined $mfssubfolder) {
+        push @$cmd, '-o', "mfssubfolder=$mfssubfolder";
+    }
+
+    push @$cmd, $scfg->{path};
 
     run_command($cmd, errmsg => "mount error");
 }
 
-# Configuration
+sub moosefs_unmount {
+    my ($scfg) = @_;
+
+    my $mountdata = PVE::ProcFSTools::parse_proc_mounts();
+
+    my $path = $scfg->{path};
+
+    my $mfsmaster = $scfg->{mfsmaster};
+
+    my $mfsport = $scfg->{mfsport} ? $scfg->{mfsport} : '9421';
+
+    if (moosefs_is_mounted($mfsmaster, $mfsport, $path, $mountdata)) {
+        my $cmd = ['/bin/umount', $path];
+        run_command($cmd, errmsg => 'umount error');
+    }
+}
 
 sub api {
     return 10;
@@ -64,15 +98,19 @@ sub plugindata {
 sub properties {
     return {
         mfsmaster => { 
-            description => "MooseFS master to use for connection.",
+            description => "MooseFS master to use for connection (default 'mfsmaster').",
             type => 'string',
         },
         mfsport => { 
-            description => "Port with which to connect to the MooseFS master",
+            description => "Port with which to connect to the MooseFS master (default 9421)",
             type => 'string',
         },
         mfspassword => {
-            description => "Password with which to connect to the MooseFS master",
+            description => "Password with which to connect to the MooseFS master (default none)",
+            type => 'string',
+        },
+        mfssubfolder => {
+            description => "Define subfolder to mount as root (default: /)",
             type => 'string',
         }
     };
@@ -80,16 +118,131 @@ sub properties {
 
 sub options {
     return {
-    path => { fixed => 1 },
-    mfsmaster => { optional => 1 },
-    mfsport => { optional => 1 },
-    mfspassword => { optional => 1 },
-    subdir => { optional => 1 },
-    disable => { optional => 1 },
+        path => { fixed => 1 },
+        mfsmaster => { optional => 1 },
+        mfsport => { optional => 1 },
+        mfspassword => { optional => 1 },
+        mfssubfolder => { optional => 1 },
+        disable => { optional => 1 },
+        shared => { optional => 1 },
+        content => { optional => 1 },
     };
 }
 
-# Storage implementation
+sub volume_has_feature {
+    my ($class, $scfg, $feature, $storeid, $volname, $snapname, $running) = @_;
+    my $features = {
+        snapshot => {
+            current => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+            snap => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 }
+        },
+        clone => {
+            base => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+            current => { raw => 1 },
+            snap => { raw => 1 },
+        },
+        template => {
+            current => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+        },
+        copy => {
+            base => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+            current => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+            snap => { qcow2 => 1, raw => 1 },
+        },
+        sparseinit => {
+            base => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+            current => { qcow2 => 1, raw => 1, vmdk => 1, subvol => 1 },
+        },
+    };
+
+    my ($vtype, $name, $vmid, $basename, $basevmid, $isBase, $format) = $class->parse_volname($volname);
+
+    my $key = undef;
+    if ($snapname) {
+        $key = 'snap';
+    } else {
+        $key =  $isBase ? 'base' : 'current';
+    }
+
+    if (defined($features->{$feature}->{$key}->{$format})) {
+        return 1;
+    }
+    return undef;
+}
+
+sub parse_name_dir {
+    my $name = shift;
+    return PVE::Storage::Plugin::parse_name_dir($name);
+}
+
+sub parse_volname {
+    my ($class, $volname) = @_;
+    return PVE::Storage::Plugin::parse_volname(@_);
+}
+
+sub volume_snapshot {
+    my ($class, $scfg, $storeid, $volname, $snap) = @_;
+
+    my ($storageType, $name, $vmid, $basename, $basedvmid, $isBase, $format) = $class->parse_volname($volname);
+
+    if ($format ne 'raw') {
+        return PVE::Storage::Plugin::volume_snapshot(@_);
+    }
+
+    die "snapshots not supported for this storage type" if $storageType ne 'images';
+
+    my $mountpoint = $scfg->{path};
+
+    my $snapdir = "$mountpoint/images/$vmid/snaps/$snap";
+
+    File::Path::make_path($snapdir);
+
+    print "running '/usr/bin/mfsmakesnapshot $mountpoint/images/$vmid/$name $snapdir/$name'\n";
+
+    my $cmd = ['/usr/bin/mfsmakesnapshot', "$mountpoint/images/$vmid/$name", "$snapdir/$name"];
+
+    run_command($cmd, errmsg => 'An error occurred while making the snapshot');
+
+    return undef;
+}
+
+sub volume_snapshot_delete {
+    my ($class, $scfg, $storeid, $volname, $snap, $running) = @_;
+
+    my ($storageType, $name, $vmid, $basename, $basedvmid, $isBase, $format) = $class->parse_volname($volname);
+
+    if ($format ne 'raw') {
+        return PVE::Storage::Plugin::volume_snapshot_delete(@_);
+    }
+
+    my $mountpoint = $scfg->{path};
+
+    my $cmd = ['/usr/bin/rm', '-rf', "$mountpoint/images/$vmid/snaps/$snap/$basename"];
+
+    run_command($cmd, errmsg => 'An error occurred while deleting the snapshot');
+
+    return undef;
+}
+
+sub volume_snapshot_rollback {
+    my ($class, $scfg, $storeid, $volname, $snap) = @_;
+
+    my ($storageType, $name, $vmid, $basename, $basedvmid, $isBase, $format) = $class->parse_volname($volname);
+
+    if ($format ne 'raw') {
+        return PVE::Storage::Plugin::volume_snapshot_rollback(@_);
+    }
+
+    my $mountpoint = $scfg->{path};
+
+    my $snapdir = "$mountpoint/images/$vmid/snaps/$snap";
+
+    my $cmd = ['/usr/bin/mfsmakesnapshot', '-o', "$snapdir/$name", "$mountpoint/images/$vmid/$name"];
+
+    run_command($cmd, errmsg => 'An error occurred while restoring the snapshot');
+
+    return undef;
+}
 
 sub status {
     my ($class, $storeid, $scfg, $cache) = @_;
@@ -109,7 +262,6 @@ sub status {
     return $class->SUPER::status($storeid, $scfg, $cache);
 }
 
-
 sub activate_storage {
     my ($class, $storeid, $scfg, $cache) = @_;
 
@@ -122,8 +274,6 @@ sub activate_storage {
 
     my $mfsport = $scfg->{mfsport} ? $scfg->{mfsport} : '9421';
 
-    my $mfspassword = $scfg->{mfspassword};
-
     if (!moosefs_is_mounted($mfsmaster, $mfsport, $path, $cache->{mountdata})) {
         
         mkpath $path if !(defined($scfg->{mkdir}) && !$scfg->{mkdir});
@@ -131,7 +281,7 @@ sub activate_storage {
         die "unable to activate storage '$storeid' - " .
             "directory '$path' does not exist\n" if ! -d $path;
 
-        moosefs_mount($mfsmaster, $path, $mfspassword);
+        moosefs_mount($scfg);
     }
 
     $class->SUPER::activate_storage($storeid, $scfg, $cache);
@@ -139,20 +289,7 @@ sub activate_storage {
 
 sub deactivate_storage {
     my ($class, $storeid, $scfg, $cache) = @_;
-
-    $cache->{mountdata} = PVE::ProcFSTools::parse_proc_mounts()
-        if !$cache->{mountdata};
-
-    my $path = $scfg->{path};
-
-    my $mfsmaster = $scfg->{mfsmaster};
-
-    my $mfsport = $scfg->{mfsport} ? $scfg->{mfsport} : '9421';
-
-    if (moosefs_is_mounted($mfsmaster, $mfsport, $path, $cache->{mountdata})) {
-        my $cmd = ['/bin/umount', $path];
-        run_command($cmd, errmsg => 'umount error');
-    }
+    moosefs_unmount($scfg);
 }
 
 1;

--- a/MooseFSPlugin.pm
+++ b/MooseFSPlugin.pm
@@ -23,7 +23,7 @@ sub moosefs_is_mounted {
     # on a fuse filesystem with the correct mountpoint
     return $mountpoint if grep {
         $_->[2] eq 'fuse' &&
-        $_->[0] =~ /^mfs#\Q$mfsmaster\E\Q:\E\Q$mfsport\E$/ &&
+        $_->[0] =~ /^mfs(#|\\043)\Q$mfsmaster\E\Q:\E\Q$mfsport\E$/ &&
         $_->[1] eq $mountpoint
     } @$mountdata;
     return undef;

--- a/copyright
+++ b/copyright
@@ -1,6 +1,6 @@
 Copyright (C) 2022 Benjamin Arntzen <zorlin@gmail.com>
 
-This software is written by Benjamin Arntzen <zorlin@gmail.com>
+This software is written by Benjamin Arntzen <zorlin@gmail.com> and Aaron Wright <anw@outlook.com>
 Based on plugin for NetApp by Dmitry Petuhov <mityapetuhov@gmail.com>
 Based on plugin for cluster-mode NFS by Alexandre Derumier <aderumier@odiso.com>
 


### PR DESCRIPTION
On PVE 8.1/Debian Bookworm, /proc/mounts returns `mfs\043mfsmaster...` instead of `mfs#mfsmaster...`.  The existing code thinks MFS is never mounted.

Also added support for snapshots for raw files.

Fixes #1 (if you add `--shared 1` in your `pvesm add` command), and #4.