### PR TITLE
Add initial mfsbdev support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.1
+VERSION=0.1.2
 PACKAGE=libpve-storage-custom-moosefs-perl
 PKGREL=1
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ MooseFS on Proxmox.
 * Support for MooseFS clusters with passwords and subfolders
 * Live migrate VMs between Proxmox hosts with the VMs living on MooseFS storage
 * Cleanly unmounts MooseFS when removed
+* MooseFS block device (`mfsbdev`) support for high performance
 
 ## Future features
 * Instant snapshots and rollbacks
-* MooseFS block device (`mfsbdev`) support for high performance
 
 ## DISCLAIMER
 This is **HIGHLY EXPERIMENTAL!** I'm running it in production, but you should be careful.
@@ -74,3 +74,6 @@ v0.1.0 - Initial release
 v0.1.1 - Bug fixes
 * Add 'container' as an option in the Proxmox GUI to allow containers to be stored on MooseFS
 * Allow leading `/` on mfssubfolder
+
+v0.1.2 - Features
+* Initial support for the MooseFS block device (mfsbdev)

--- a/changelog.Debian
+++ b/changelog.Debian
@@ -1,5 +1,5 @@
-libpve-storage-custom-moosefs-perl (0.1.0-1) unstable; urgency=medium
+libpve-storage-custom-moosefs-perl (0.1.2-1) unstable; urgency=medium
 
-  * Initial release
+  * Initial support for mfsbdev block device backend.
 
- -- Benjamin Arntzen <zorlin@gmail.com>  Tue, 19 Apr 2022 04:20:06 +0800
+ -- Benjamin Arntzen <zorlin@gmail.com>  Mon, 17 Mar 2025 14:00:00 +0000


### PR DESCRIPTION
## Summary
- add `mfsbdev` option
- implement `alloc_image` and `free_image` for mfsbdev
- document new feature and bump version

## Testing
- `perl -c MooseFSPlugin.pm` *(fails: Can't locate PVE::Storage::Plugin.pm)*